### PR TITLE
second instance using same config, just new ports

### DIFF
--- a/loanFinal/readme.txt
+++ b/loanFinal/readme.txt
@@ -9,7 +9,7 @@ To run multiple instances of the service with different .yml.
 	java -jar build/libs/loancalc.jar server build/resources/main/loancalc.yml
 	
 - To run 2nd instance on a different port, run:
-	java -jar build/libs/loancalc.jar server build/resources/main/loancalc.yml -Ddw.server.applicationConnectors[0].port=9090 -Ddw.server.adminConnectors[0].port=9091 
+	java -Ddw.server.applicationConnectors[0].port=9090 -Ddw.server.adminConnectors[0].port=9091 -jar build/libs/loancalc.jar server build/resources/main/loancalc.yml  
 	
 - Access the URL by doing:
 	http://localhost:9000/loan //this returns calculation based on defaults of 15000, 3.0 and 60

--- a/loanFinal/readme.txt
+++ b/loanFinal/readme.txt
@@ -9,7 +9,7 @@ To run multiple instances of the service with different .yml.
 	java -jar build/libs/loancalc.jar server build/resources/main/loancalc.yml
 	
 - To run 2nd instance on a different port, run:
-	java -Ddropwizard.config=src/main/resources/loancalc.yml -jar build/libs/hello-world.jar
+	java -jar build/libs/loancalc.jar server build/resources/main/loancalc.yml -Ddw.server.applicationConnectors[0].port=9090 -Ddw.server.adminConnectors[0].port=9091 
 	
 - Access the URL by doing:
 	http://localhost:9000/loan //this returns calculation based on defaults of 15000, 3.0 and 60


### PR DESCRIPTION
The previous example used a (copy of) the same file as the first instance.  requiring a config edit. 
Alternative fix would be to include two loancalcX.yml files with different port mappings.
